### PR TITLE
Source featured projects from GitHub in real time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *"
 
 permissions:
   contents: read
@@ -36,6 +38,11 @@ jobs:
           BOOKING_PASSWORDS: ${{ secrets.BOOKING_PASSWORDS }}
           ENV_OUTPUT: client/.env
         run: node scripts/hash-passwords.mjs
+
+      - name: Refresh GitHub project data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/fetch-github-projects.mjs || echo "GitHub fetch failed — building with committed snapshot"
 
       - name: Build
         run: npm run build

--- a/client/src/components/projects.tsx
+++ b/client/src/components/projects.tsx
@@ -1,19 +1,9 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Github } from "lucide-react";
-
-interface Project {
-  title: string;
-  description: string;
-  image: string;
-  alt: string;
-  technologies: string[];
-  titleColor: string;
-  codeUrl?: string;
-  demoUrl?: string;
-  linksNote?: string;
-}
+import { ExternalLink, Github, Star } from "lucide-react";
+import { FEATURED_PROJECTS } from "@/lib/featured-projects";
+import { useGithubRepos } from "@/hooks/use-github-repos";
 
 const TECH_COLORS: Record<string, string> = {
   "C++": "bg-blue-600/20 text-blue-400",
@@ -25,72 +15,48 @@ const TECH_COLORS: Record<string, string> = {
   "py-torch": "bg-orange-600/20 text-orange-400",
   "API": "bg-green-600/20 text-green-400",
   "HTML / JS": "bg-yellow-600/20 text-yellow-400",
+  "AI Security": "bg-purple-600/20 text-purple-400",
+  "CLI": "bg-cyan-600/20 text-cyan-400",
 };
 
 const DEFAULT_TECH_COLOR = "bg-gray-600/20 text-gray-300";
 
+function formatPushedAt(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 export default function Projects() {
-  const projects: Project[] = [
-    {
-       title: "AutoMenu",
-       description: "After having to make a CLI menu multiple times for multiple classes, I decided to make a general function to do it automatically.",
-       image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='50' text-anchor='middle' fill='%2306b6d4' font-family='monospace' font-size='16' font-weight='bold'%3EC++ CLI Menu%3C/text%3E%3Ctext x='50' y='90' fill='%2310b981' font-family='monospace' font-size='12'%3E1. Option One%3C/text%3E%3Ctext x='50' y='110' fill='%2310b981' font-family='monospace' font-size='12'%3E2. Option Two%3C/text%3E%3Ctext x='50' y='130' fill='%2310b981' font-family='monospace' font-size='12'%3E3. Option Three%3C/text%3E%3Ctext x='50' y='150' fill='%23fbbf24' font-family='monospace' font-size='12'%3EEnter choice: __%3C/text%3E%3C/svg%3E",
-       alt: "C++ CLI menu interface",
-       technologies: ["C++"],
-       titleColor: "text-cyan-400",
-       codeUrl: "https://github.com/Jaynuke79/AutoMenu",
-    },
-    {
-      title: "The 100 Prisoners Problem",
-      description: "Inspired by Veritasium and spurred on by a debate with my professor, I coded up a simulation of the 100 prisoners problem.",
-      image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='30' text-anchor='middle' fill='%2310b981' font-family='Arial' font-size='18' font-weight='bold'%3E100 Prisoners Problem%3C/text%3E%3Cg transform='translate(50,60)'%3E%3Crect x='0' y='0' width='30' height='20' fill='%236b7280' stroke='%23d1d5db'/%3E%3Ctext x='15' y='15' text-anchor='middle' fill='white' font-size='10'%3E1%3C/text%3E%3Crect x='35' y='0' width='30' height='20' fill='%236b7280' stroke='%23d1d5db'/%3E%3Ctext x='50' y='15' text-anchor='middle' fill='white' font-size='10'%3E2%3C/text%3E%3Ctext x='80' y='15' fill='%23fbbf24' font-size='12'%3E...100%3C/text%3E%3C/g%3E%3Ctext x='200' y='120' text-anchor='middle' fill='%2306b6d4' font-size='14'%3ESuccess Rate: 31.18%%3C/text%3E%3Ctext x='200' y='140' text-anchor='middle' fill='%23ef4444' font-size='12'%3ESimulations: 10,000%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%23a855f7' font-size='12'%3EStrategy: Optimal Loop%3C/text%3E%3C/svg%3E",
-      alt: "100 prisoners problem simulation visualization",
-      technologies: ["C++"],
-      titleColor: "text-green-400",
-      codeUrl: "https://github.com/Jaynuke79/100PrisonerProblem",
-    },
-    {
-      title: "Machine Learning Research Lead",
-      description: "Author of the paper: The Effect of Increased Dimensionality on Detecting Malicious Packets using Machine Learning on IoMT WiFi network traffic.",
-      image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%2310b981' font-family='Arial' font-size='16' font-weight='bold'%3EML Cybersecurity Research%3C/text%3E%3Cg transform='translate(50,50)'%3E%3Ccircle cx='50' cy='30' r='8' fill='%2306b6d4'/%3E%3Ccircle cx='100' cy='20' r='6' fill='%23ef4444'/%3E%3Ccircle cx='150' cy='40' r='7' fill='%2310b981'/%3E%3Ccircle cx='200' cy='25' r='5' fill='%23fbbf24'/%3E%3Ctext x='50' y='50' text-anchor='middle' fill='%2306b6d4' font-size='8'%3ENormal%3C/text%3E%3Ctext x='100' y='40' text-anchor='middle' fill='%23ef4444' font-size='8'%3EMalicious%3C/text%3E%3C/g%3E%3Ctext x='200' y='120' text-anchor='middle' fill='%23a855f7' font-size='12'%3EIoMT WiFi Traffic Analysis%3C/text%3E%3Ctext x='200' y='140' text-anchor='middle' fill='%23fbbf24' font-size='12'%3EAccuracy: 94.7%%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%2306b6d4' font-size='10'%3EJupyter • Scikit-learn • Pandas%3C/text%3E%3C/svg%3E",
-      alt: "Machine learning cybersecurity research visualization",
-      technologies: ["Jupyter Notebook","Sk-learn","Pandas","Numpy"],
-      titleColor: "text-green-400",
-      linksNote: "Paper not publicly published — available on request.",
-    },
-    {
-      title: "Pokemon Detector Webapp",
-      description: "Trained a machine learning algorithm to detect Gen1 Pokemon and made a webapp.",
-      image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%23a855f7' font-family='Arial' font-size='16' font-weight='bold'%3EPokemon AI Detector%3C/text%3E%3Ccircle cx='120' cy='80' r='25' fill='none' stroke='%23ef4444' stroke-width='3'/%3E%3Ccircle cx='120' cy='80' r='15' fill='%23ef4444'/%3E%3Ccircle cx='120' cy='75' r='8' fill='white'/%3E%3Crect x='115' y='105' width='10' height='5' fill='%236b7280'/%3E%3Ctext x='280' y='70' fill='%2310b981' font-size='14' font-weight='bold'%3EPikachu%3C/text%3E%3Ctext x='280' y='90' fill='%23fbbf24' font-size='12'%3EConfidence: 96.8%%3C/text%3E%3Ctext x='280' y='110' fill='%2306b6d4' font-size='10'%3EGen 1 Electric Type%3C/text%3E%3Crect x='50' y='130' width='300' height='40' fill='%231f2937' stroke='%234b5563'/%3E%3Ctext x='200' y='145' text-anchor='middle' fill='%239ca3af' font-size='10'%3EDrop image or click to upload%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%236b7280' font-size='8'%3EPyTorch • Web Interface%3C/text%3E%3C/svg%3E",
-      alt: "Pokemon detection web application interface",
-      technologies: ["py-torch", "HTML / JS"],
-      titleColor: "text-purple-400",
-      codeUrl: "https://github.com/Jaynuke79/PokemonDetector",
-      demoUrl: "https://pokemon-detector-demo.vercel.app",
-    },
-    {
-      title: "Weather APP",
-      description: "A classic beginning coder project.",
-      image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%23fbbf24' font-family='Arial' font-size='18' font-weight='bold'%3EWeather App%3C/text%3E%3Ccircle cx='120' cy='80' r='20' fill='%23fbbf24'/%3E%3Cpath d='M 100 80 Q 100 70 110 70 Q 120 60 130 70 Q 140 70 140 80' fill='%236b7280'/%3E%3Ctext x='200' y='70' fill='%23fbbf24' font-size='24' font-weight='bold'%3E72°F%3C/text%3E%3Ctext x='200' y='90' fill='%2306b6d4' font-size='14'%3ESunny%3C/text%3E%3Ctext x='200' y='110' fill='%2310b981' font-size='12'%3EGrand Junction, CO%3C/text%3E%3Ctext x='200' y='130' fill='%239ca3af' font-size='10'%3EHumidity: 45%% | Wind: 8 mph%3C/text%3E%3Ctext x='200' y='150' fill='%23a855f7' font-size='10'%3EPowered by Weather API%3C/text%3E%3C/svg%3E",
-      alt: "Weather application interface showing temperature and conditions",
-      technologies: ["Python","API","HTML / JS"],
-      titleColor: "text-yellow-400",
-      codeUrl: "https://github.com/Jaynuke79/WeatherApiApp",
-    },
-  ];
+  const repos = useGithubRepos();
+
+  const projects = FEATURED_PROJECTS.map((featured) => {
+    const repo = featured.repo ? repos.get(featured.repo) : undefined;
+    return {
+      ...featured,
+      description: featured.description ?? repo?.description ?? "",
+      codeUrl: featured.codeUrl ?? repo?.html_url,
+      demoUrl: featured.demoUrl ?? (repo?.homepage || undefined),
+      stars: repo?.stargazers_count,
+      language: repo?.language,
+      pushedAt: repo?.pushed_at,
+    };
+  });
 
   return (
     <section id="projects" className="py-20 bg-black">
       <div className="max-w-6xl mx-auto px-4">
         <h2 className="text-4xl font-bold text-center mb-16 gradient-text">Featured Projects and Events</h2>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {projects.map((project, index) => (
-            <Card 
-              key={index}
+          {projects.map((project) => (
+            <Card
+              key={project.title}
               className="glass-morphism border-gray-800 hover:scale-105 transition-all duration-300 group hover:glow-blue"
             >
               <CardContent className="p-6">
-                <img 
+                <img
                   src={project.image}
                   alt={project.alt}
                   className="w-full h-48 object-cover rounded-lg mb-4"
@@ -102,6 +68,16 @@ export default function Projects() {
                 <p className="text-gray-300 mb-4 text-sm leading-relaxed">
                   {project.description}
                 </p>
+                {project.pushedAt && (
+                  <div className="flex items-center gap-3 text-xs text-gray-400 mb-4">
+                    <span className="flex items-center">
+                      <Star className="mr-1 h-3 w-3" />
+                      {project.stars}
+                    </span>
+                    {project.language && <span>{project.language}</span>}
+                    <span>Updated {formatPushedAt(project.pushedAt)}</span>
+                  </div>
+                )}
                 <div className="flex flex-wrap gap-2 mb-4">
                   {project.technologies.map((tech) => (
                     <Badge

--- a/client/src/hooks/use-github-repos.ts
+++ b/client/src/hooks/use-github-repos.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { fetchGithubRepos, type GithubRepo } from "@/lib/github";
+import bakedRepos from "@/lib/github-projects.json";
+
+function toMap(repos: GithubRepo[]): Map<string, GithubRepo> {
+  return new Map(repos.map((repo) => [repo.name, repo]));
+}
+
+export function useGithubRepos(): Map<string, GithubRepo> {
+  const [repos, setRepos] = useState(() => toMap(bakedRepos as GithubRepo[]));
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchGithubRepos().then((live) => {
+      if (live && !cancelled) setRepos(toMap(live));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return repos;
+}

--- a/client/src/lib/featured-projects.ts
+++ b/client/src/lib/featured-projects.ts
@@ -1,0 +1,79 @@
+export interface FeaturedProject {
+  repo?: string;
+  title: string;
+  description?: string;
+  image: string;
+  alt: string;
+  technologies: string[];
+  titleColor: string;
+  codeUrl?: string;
+  demoUrl?: string;
+  linksNote?: string;
+}
+
+export const FEATURED_PROJECTS: FeaturedProject[] = [
+  {
+    repo: "Intentionally-Vulnerable-Bad-rAG",
+    title: "Intentionally Vulnerable Bad RAG",
+    image: "https://opengraph.githubassets.com/portfolio/Jaynuke79/Intentionally-Vulnerable-Bad-rAG",
+    alt: "Intentionally Vulnerable Bad RAG repository card",
+    technologies: ["Python", "AI Security"],
+    titleColor: "text-red-400",
+  },
+  {
+    repo: "Social-Media-Downloader",
+    title: "Social Media Downloader",
+    image: "https://opengraph.githubassets.com/portfolio/Jaynuke79/Social-Media-Downloader",
+    alt: "Social Media Downloader repository card",
+    technologies: ["Python", "CLI"],
+    titleColor: "text-cyan-400",
+  },
+  {
+    title: "Machine Learning Research Lead",
+    description:
+      "Author of the paper: The Effect of Increased Dimensionality on Detecting Malicious Packets using Machine Learning on IoMT WiFi network traffic.",
+    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%2310b981' font-family='Arial' font-size='16' font-weight='bold'%3EML Cybersecurity Research%3C/text%3E%3Cg transform='translate(50,50)'%3E%3Ccircle cx='50' cy='30' r='8' fill='%2306b6d4'/%3E%3Ccircle cx='100' cy='20' r='6' fill='%23ef4444'/%3E%3Ccircle cx='150' cy='40' r='7' fill='%2310b981'/%3E%3Ccircle cx='200' cy='25' r='5' fill='%23fbbf24'/%3E%3Ctext x='50' y='50' text-anchor='middle' fill='%2306b6d4' font-size='8'%3ENormal%3C/text%3E%3Ctext x='100' y='40' text-anchor='middle' fill='%23ef4444' font-size='8'%3EMalicious%3C/text%3E%3C/g%3E%3Ctext x='200' y='120' text-anchor='middle' fill='%23a855f7' font-size='12'%3EIoMT WiFi Traffic Analysis%3C/text%3E%3Ctext x='200' y='140' text-anchor='middle' fill='%23fbbf24' font-size='12'%3EAccuracy: 94.7%%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%2306b6d4' font-size='10'%3EJupyter • Scikit-learn • Pandas%3C/text%3E%3C/svg%3E",
+    alt: "Machine learning cybersecurity research visualization",
+    technologies: ["Jupyter Notebook", "Sk-learn", "Pandas", "Numpy"],
+    titleColor: "text-green-400",
+    linksNote: "Paper not publicly published — available on request.",
+  },
+  {
+    repo: "PokemonDetector",
+    title: "Pokemon Detector Webapp",
+    description: "Trained a machine learning algorithm to detect Gen1 Pokemon and made a webapp.",
+    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%23a855f7' font-family='Arial' font-size='16' font-weight='bold'%3EPokemon AI Detector%3C/text%3E%3Ccircle cx='120' cy='80' r='25' fill='none' stroke='%23ef4444' stroke-width='3'/%3E%3Ccircle cx='120' cy='80' r='15' fill='%23ef4444'/%3E%3Ccircle cx='120' cy='75' r='8' fill='white'/%3E%3Crect x='115' y='105' width='10' height='5' fill='%236b7280'/%3E%3Ctext x='280' y='70' fill='%2310b981' font-size='14' font-weight='bold'%3EPikachu%3C/text%3E%3Ctext x='280' y='90' fill='%23fbbf24' font-size='12'%3EConfidence: 96.8%%3C/text%3E%3Ctext x='280' y='110' fill='%2306b6d4' font-size='10'%3EGen 1 Electric Type%3C/text%3E%3Crect x='50' y='130' width='300' height='40' fill='%231f2937' stroke='%234b5563'/%3E%3Ctext x='200' y='145' text-anchor='middle' fill='%239ca3af' font-size='10'%3EDrop image or click to upload%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%236b7280' font-size='8'%3EPyTorch • Web Interface%3C/text%3E%3C/svg%3E",
+    alt: "Pokemon detection web application interface",
+    technologies: ["py-torch", "HTML / JS"],
+    titleColor: "text-purple-400",
+  },
+  {
+    repo: "AutoMenu",
+    title: "AutoMenu",
+    description:
+      "After having to make a CLI menu multiple times for multiple classes, I decided to make a general function to do it automatically.",
+    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='50' text-anchor='middle' fill='%2306b6d4' font-family='monospace' font-size='16' font-weight='bold'%3EC++ CLI Menu%3C/text%3E%3Ctext x='50' y='90' fill='%2310b981' font-family='monospace' font-size='12'%3E1. Option One%3C/text%3E%3Ctext x='50' y='110' fill='%2310b981' font-family='monospace' font-size='12'%3E2. Option Two%3C/text%3E%3Ctext x='50' y='130' fill='%2310b981' font-family='monospace' font-size='12'%3E3. Option Three%3C/text%3E%3Ctext x='50' y='150' fill='%23fbbf24' font-family='monospace' font-size='12'%3EEnter choice: __%3C/text%3E%3C/svg%3E",
+    alt: "C++ CLI menu interface",
+    technologies: ["C++"],
+    titleColor: "text-cyan-400",
+  },
+  {
+    repo: "100PrisonerProblem",
+    title: "The 100 Prisoners Problem",
+    description:
+      "Inspired by Veritasium and spurred on by a debate with my professor, I coded up a simulation of the 100 prisoners problem.",
+    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='30' text-anchor='middle' fill='%2310b981' font-family='Arial' font-size='18' font-weight='bold'%3E100 Prisoners Problem%3C/text%3E%3Cg transform='translate(50,60)'%3E%3Crect x='0' y='0' width='30' height='20' fill='%236b7280' stroke='%23d1d5db'/%3E%3Ctext x='15' y='15' text-anchor='middle' fill='white' font-size='10'%3E1%3C/text%3E%3Crect x='35' y='0' width='30' height='20' fill='%236b7280' stroke='%23d1d5db'/%3E%3Ctext x='50' y='15' text-anchor='middle' fill='white' font-size='10'%3E2%3C/text%3E%3Ctext x='80' y='15' fill='%23fbbf24' font-size='12'%3E...100%3C/text%3E%3C/g%3E%3Ctext x='200' y='120' text-anchor='middle' fill='%2306b6d4' font-size='14'%3ESuccess Rate: 31.18%%3C/text%3E%3Ctext x='200' y='140' text-anchor='middle' fill='%23ef4444' font-size='12'%3ESimulations: 10,000%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%23a855f7' font-size='12'%3EStrategy: Optimal Loop%3C/text%3E%3C/svg%3E",
+    alt: "100 prisoners problem simulation visualization",
+    technologies: ["C++"],
+    titleColor: "text-green-400",
+  },
+  {
+    repo: "WeatherApiApp",
+    title: "Weather APP",
+    description: "A classic beginning coder project.",
+    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%23fbbf24' font-family='Arial' font-size='18' font-weight='bold'%3EWeather App%3C/text%3E%3Ccircle cx='120' cy='80' r='20' fill='%23fbbf24'/%3E%3Cpath d='M 100 80 Q 100 70 110 70 Q 120 60 130 70 Q 140 70 140 80' fill='%236b7280'/%3E%3Ctext x='200' y='70' fill='%23fbbf24' font-size='24' font-weight='bold'%3E72°F%3C/text%3E%3Ctext x='200' y='90' fill='%2306b6d4' font-size='14'%3ESunny%3C/text%3E%3Ctext x='200' y='110' fill='%2310b981' font-size='12'%3EGrand Junction, CO%3C/text%3E%3Ctext x='200' y='130' fill='%239ca3af' font-size='10'%3EHumidity: 45%% | Wind: 8 mph%3C/text%3E%3Ctext x='200' y='150' fill='%23a855f7' font-size='10'%3EPowered by Weather API%3C/text%3E%3C/svg%3E",
+    alt: "Weather application interface showing temperature and conditions",
+    technologies: ["Python", "API", "HTML / JS"],
+    titleColor: "text-yellow-400",
+  },
+];

--- a/client/src/lib/github-projects.json
+++ b/client/src/lib/github-projects.json
@@ -1,0 +1,165 @@
+[
+  {
+    "name": "Portfolio",
+    "description": "Website Digital Portfolio",
+    "html_url": "https://github.com/Jaynuke79/Portfolio",
+    "homepage": "https://j2a3e.com/",
+    "language": "TypeScript",
+    "stargazers_count": 0,
+    "pushed_at": "2026-07-18T02:32:17Z",
+    "topics": []
+  },
+  {
+    "name": "mythology-final-project",
+    "description": null,
+    "html_url": "https://github.com/Jaynuke79/mythology-final-project",
+    "homepage": "https://jaynuke79.github.io/mythology-final-project/",
+    "language": "HTML",
+    "stargazers_count": 0,
+    "pushed_at": "2026-05-08T04:18:40Z",
+    "topics": []
+  },
+  {
+    "name": "Jaynuke79",
+    "description": "Config files for my GitHub profile.",
+    "html_url": "https://github.com/Jaynuke79/Jaynuke79",
+    "homepage": "https://github.com/Jaynuke79",
+    "language": null,
+    "stargazers_count": 0,
+    "pushed_at": "2026-04-30T23:27:03Z",
+    "topics": [
+      "config",
+      "github-config"
+    ]
+  },
+  {
+    "name": "PokemonDetector",
+    "description": "I built and trained a model to identify gen 1 pokemon. Demo website hosted on vercel.",
+    "html_url": "https://github.com/Jaynuke79/PokemonDetector",
+    "homepage": "https://pokemon-detector-demo.vercel.app",
+    "language": "Python",
+    "stargazers_count": 0,
+    "pushed_at": "2026-03-03T19:33:19Z",
+    "topics": []
+  },
+  {
+    "name": "snowball-ticket-calculator",
+    "description": null,
+    "html_url": "https://github.com/Jaynuke79/snowball-ticket-calculator",
+    "homepage": null,
+    "language": "Jupyter Notebook",
+    "stargazers_count": 0,
+    "pushed_at": "2026-02-27T23:56:41Z",
+    "topics": []
+  },
+  {
+    "name": "Intentionally-Vulnerable-Bad-rAG",
+    "description": "This project demonstrates why you should give AI models the least amount of personal information necessary.",
+    "html_url": "https://github.com/Jaynuke79/Intentionally-Vulnerable-Bad-rAG",
+    "homepage": "",
+    "language": "Python",
+    "stargazers_count": 0,
+    "pushed_at": "2025-10-17T03:52:44Z",
+    "topics": []
+  },
+  {
+    "name": "Social-Media-Downloader",
+    "description": "Social Media Downloader is your CLI bestie for grabbing videos, reels, and posts from YouTube, TikTok, Instagram, Facebook and more. With batch downloads, custom settings, and logs, it’s ready to slay on Windows & Linux, and via PyPI.",
+    "html_url": "https://github.com/Jaynuke79/Social-Media-Downloader",
+    "homepage": "",
+    "language": "Python",
+    "stargazers_count": 0,
+    "pushed_at": "2025-09-08T03:17:32Z",
+    "topics": []
+  },
+  {
+    "name": "100PrisonerProblem",
+    "description": "Coding up the 100 Prisoner Problem",
+    "html_url": "https://github.com/Jaynuke79/100PrisonerProblem",
+    "homepage": "",
+    "language": "C++",
+    "stargazers_count": 0,
+    "pushed_at": "2025-07-06T01:29:47Z",
+    "topics": []
+  },
+  {
+    "name": "github-readme-stats",
+    "description": ":zap: Dynamically generated stats for your github readmes",
+    "html_url": "https://github.com/Jaynuke79/github-readme-stats",
+    "homepage": "https://github-readme-stats.vercel.app",
+    "language": null,
+    "stargazers_count": 0,
+    "pushed_at": "2025-07-03T15:16:51Z",
+    "topics": []
+  },
+  {
+    "name": "WeatherApiApp",
+    "description": "Beginner weather app that uses an api to get data",
+    "html_url": "https://github.com/Jaynuke79/WeatherApiApp",
+    "homepage": null,
+    "language": "Python",
+    "stargazers_count": 0,
+    "pushed_at": "2025-06-25T21:59:49Z",
+    "topics": []
+  },
+  {
+    "name": "Digital_Portfolio",
+    "description": null,
+    "html_url": "https://github.com/Jaynuke79/Digital_Portfolio",
+    "homepage": null,
+    "language": null,
+    "stargazers_count": 0,
+    "pushed_at": "2025-06-08T02:33:21Z",
+    "topics": []
+  },
+  {
+    "name": "test_pages",
+    "description": null,
+    "html_url": "https://github.com/Jaynuke79/test_pages",
+    "homepage": null,
+    "language": "HTML",
+    "stargazers_count": 0,
+    "pushed_at": "2025-06-06T04:22:24Z",
+    "topics": []
+  },
+  {
+    "name": "OOP-Student-Showcase",
+    "description": null,
+    "html_url": "https://github.com/Jaynuke79/OOP-Student-Showcase",
+    "homepage": null,
+    "language": "HTML",
+    "stargazers_count": 0,
+    "pushed_at": "2025-05-07T22:25:30Z",
+    "topics": []
+  },
+  {
+    "name": "CS-Club",
+    "description": null,
+    "html_url": "https://github.com/Jaynuke79/CS-Club",
+    "homepage": null,
+    "language": "Jupyter Notebook",
+    "stargazers_count": 0,
+    "pushed_at": "2025-02-13T18:09:15Z",
+    "topics": []
+  },
+  {
+    "name": "AutoMenu",
+    "description": "Takes in functions and creates an automatic menu in the terminal. Useful for quick class assignments.",
+    "html_url": "https://github.com/Jaynuke79/AutoMenu",
+    "homepage": "",
+    "language": "C++",
+    "stargazers_count": 0,
+    "pushed_at": "2025-01-21T18:06:02Z",
+    "topics": []
+  },
+  {
+    "name": "PlayingWithData",
+    "description": "random data to visualize, manipulate, and otherwise play with",
+    "html_url": "https://github.com/Jaynuke79/PlayingWithData",
+    "homepage": null,
+    "language": "Jupyter Notebook",
+    "stargazers_count": 0,
+    "pushed_at": "2025-01-16T02:36:49Z",
+    "topics": []
+  }
+]

--- a/client/src/lib/github.ts
+++ b/client/src/lib/github.ts
@@ -1,0 +1,71 @@
+export const GITHUB_USERNAME = "Jaynuke79";
+
+export interface GithubRepo {
+  name: string;
+  description: string | null;
+  html_url: string;
+  homepage: string | null;
+  language: string | null;
+  stargazers_count: number;
+  pushed_at: string;
+  topics: string[];
+}
+
+const CACHE_KEY = "github-repos-v1";
+const CACHE_TTL_MS = 30 * 60 * 1000;
+
+interface CacheEntry {
+  fetchedAt: number;
+  repos: GithubRepo[];
+}
+
+function readCache(): GithubRepo[] | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const entry: CacheEntry = JSON.parse(raw);
+    if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) return null;
+    return entry.repos;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(repos: GithubRepo[]) {
+  try {
+    const entry: CacheEntry = { fetchedAt: Date.now(), repos };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // localStorage unavailable (private mode, quota) — live data still applies this session
+  }
+}
+
+function pickRepoFields(raw: Record<string, unknown>): GithubRepo {
+  return {
+    name: raw.name as string,
+    description: (raw.description as string | null) ?? null,
+    html_url: raw.html_url as string,
+    homepage: (raw.homepage as string | null) ?? null,
+    language: (raw.language as string | null) ?? null,
+    stargazers_count: (raw.stargazers_count as number) ?? 0,
+    pushed_at: raw.pushed_at as string,
+    topics: (raw.topics as string[]) ?? [],
+  };
+}
+
+export async function fetchGithubRepos(): Promise<GithubRepo[] | null> {
+  const cached = readCache();
+  if (cached) return cached;
+  try {
+    const res = await fetch(
+      `https://api.github.com/users/${GITHUB_USERNAME}/repos?sort=pushed&per_page=100`
+    );
+    if (!res.ok) return null;
+    const data: Record<string, unknown>[] = await res.json();
+    const repos = data.map(pickRepoFields);
+    writeCache(repos);
+    return repos;
+  } catch {
+    return null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build --config vite.config.github.ts",
     "preview": "vite preview",
     "check": "tsc",
-    "hash-passwords": "node scripts/hash-passwords.mjs"
+    "hash-passwords": "node scripts/hash-passwords.mjs",
+    "fetch-projects": "node scripts/fetch-github-projects.mjs"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/fetch-github-projects.mjs
+++ b/scripts/fetch-github-projects.mjs
@@ -1,0 +1,37 @@
+import { writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const USERNAME = 'Jaynuke79';
+const OUT_FILE = resolve(__dirname, '..', 'client/src/lib/github-projects.json');
+
+const headers = { Accept: 'application/vnd.github+json' };
+if (process.env.GH_TOKEN) {
+  headers.Authorization = `Bearer ${process.env.GH_TOKEN}`;
+}
+
+const res = await fetch(
+  `https://api.github.com/users/${USERNAME}/repos?sort=pushed&per_page=100`,
+  { headers }
+);
+if (!res.ok) {
+  console.error(`GitHub API returned ${res.status} — keeping committed snapshot`);
+  process.exit(1);
+}
+
+const data = await res.json();
+const repos = data.map((r) => ({
+  name: r.name,
+  description: r.description ?? null,
+  html_url: r.html_url,
+  homepage: r.homepage ?? null,
+  language: r.language ?? null,
+  stargazers_count: r.stargazers_count ?? 0,
+  pushed_at: r.pushed_at,
+  topics: r.topics ?? [],
+}));
+
+writeFileSync(OUT_FILE, JSON.stringify(repos, null, 2) + '\n');
+console.log(`Wrote ${repos.length} repos to client/src/lib/github-projects.json`);


### PR DESCRIPTION
## What
The Projects section is now driven by a curated list of repo names enriched live from the GitHub API, instead of a hardcoded array. Cards gain stars, primary language, and last-pushed date, and Code/Demo links come from each repo's `html_url`/`homepage`. Two active repos join the lineup: **Intentionally-Vulnerable-Bad-rAG** and **Social-Media-Downloader**.

## Why
The hardcoded list had drifted badly (5 cards vs 16 repos; every recently pushed repo missing), and keeping it current required editing TSX and redeploying.

## How
- `client/src/lib/featured-projects.ts` — curated entries (order = display order) with optional overrides; non-repo entries (ML research) render from config alone.
- `scripts/fetch-github-projects.mjs` — trims the repos API payload into `client/src/lib/github-projects.json`, the baked fallback. CI refreshes it before every build (authenticated via `github.token`), and a new daily `schedule:` trigger on deploy.yml keeps the deployed fallback fresh without pushes.
- `client/src/hooks/use-github-repos.ts` + `client/src/lib/github.ts` — render baked data immediately, then hydrate from one unauthenticated API call cached in localStorage for 30 minutes (rate limit is 60/hr/IP; failures silently keep baked data).

## Testing
`npm run check` and `npm run build` pass; the built bundle contains the live-fetch path and the baked snapshot (verified by grep). Fetch script run against the real API wrote all 16 repos.

Closes #3