### PR TITLE
Derive project card images from GitHub OpenGraph cards

### DIFF
--- a/client/src/components/projects.tsx
+++ b/client/src/components/projects.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ExternalLink, Github, Star } from "lucide-react";
 import { FEATURED_PROJECTS } from "@/lib/featured-projects";
+import { githubOgImageUrl } from "@/lib/github";
 import { useGithubRepos } from "@/hooks/use-github-repos";
 
 const TECH_COLORS: Record<string, string> = {
@@ -36,6 +37,8 @@ export default function Projects() {
     const repo = featured.repo ? repos.get(featured.repo) : undefined;
     return {
       ...featured,
+      image: featured.image ?? (featured.repo ? githubOgImageUrl(featured.repo) : ""),
+      alt: featured.alt ?? `${featured.title} repository card`,
       description: featured.description ?? repo?.description ?? "",
       codeUrl: featured.codeUrl ?? repo?.html_url,
       demoUrl: featured.demoUrl ?? (repo?.homepage || undefined),

--- a/client/src/lib/featured-projects.ts
+++ b/client/src/lib/featured-projects.ts
@@ -2,8 +2,8 @@ export interface FeaturedProject {
   repo?: string;
   title: string;
   description?: string;
-  image: string;
-  alt: string;
+  image?: string;
+  alt?: string;
   technologies: string[];
   titleColor: string;
   codeUrl?: string;
@@ -15,16 +15,12 @@ export const FEATURED_PROJECTS: FeaturedProject[] = [
   {
     repo: "Intentionally-Vulnerable-Bad-rAG",
     title: "Intentionally Vulnerable Bad RAG",
-    image: "https://opengraph.githubassets.com/portfolio/Jaynuke79/Intentionally-Vulnerable-Bad-rAG",
-    alt: "Intentionally Vulnerable Bad RAG repository card",
     technologies: ["Python", "AI Security"],
     titleColor: "text-red-400",
   },
   {
     repo: "Social-Media-Downloader",
     title: "Social Media Downloader",
-    image: "https://opengraph.githubassets.com/portfolio/Jaynuke79/Social-Media-Downloader",
-    alt: "Social Media Downloader repository card",
     technologies: ["Python", "CLI"],
     titleColor: "text-cyan-400",
   },
@@ -42,8 +38,6 @@ export const FEATURED_PROJECTS: FeaturedProject[] = [
     repo: "PokemonDetector",
     title: "Pokemon Detector Webapp",
     description: "Trained a machine learning algorithm to detect Gen1 Pokemon and made a webapp.",
-    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%23a855f7' font-family='Arial' font-size='16' font-weight='bold'%3EPokemon AI Detector%3C/text%3E%3Ccircle cx='120' cy='80' r='25' fill='none' stroke='%23ef4444' stroke-width='3'/%3E%3Ccircle cx='120' cy='80' r='15' fill='%23ef4444'/%3E%3Ccircle cx='120' cy='75' r='8' fill='white'/%3E%3Crect x='115' y='105' width='10' height='5' fill='%236b7280'/%3E%3Ctext x='280' y='70' fill='%2310b981' font-size='14' font-weight='bold'%3EPikachu%3C/text%3E%3Ctext x='280' y='90' fill='%23fbbf24' font-size='12'%3EConfidence: 96.8%%3C/text%3E%3Ctext x='280' y='110' fill='%2306b6d4' font-size='10'%3EGen 1 Electric Type%3C/text%3E%3Crect x='50' y='130' width='300' height='40' fill='%231f2937' stroke='%234b5563'/%3E%3Ctext x='200' y='145' text-anchor='middle' fill='%239ca3af' font-size='10'%3EDrop image or click to upload%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%236b7280' font-size='8'%3EPyTorch • Web Interface%3C/text%3E%3C/svg%3E",
-    alt: "Pokemon detection web application interface",
     technologies: ["py-torch", "HTML / JS"],
     titleColor: "text-purple-400",
   },
@@ -52,8 +46,6 @@ export const FEATURED_PROJECTS: FeaturedProject[] = [
     title: "AutoMenu",
     description:
       "After having to make a CLI menu multiple times for multiple classes, I decided to make a general function to do it automatically.",
-    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='50' text-anchor='middle' fill='%2306b6d4' font-family='monospace' font-size='16' font-weight='bold'%3EC++ CLI Menu%3C/text%3E%3Ctext x='50' y='90' fill='%2310b981' font-family='monospace' font-size='12'%3E1. Option One%3C/text%3E%3Ctext x='50' y='110' fill='%2310b981' font-family='monospace' font-size='12'%3E2. Option Two%3C/text%3E%3Ctext x='50' y='130' fill='%2310b981' font-family='monospace' font-size='12'%3E3. Option Three%3C/text%3E%3Ctext x='50' y='150' fill='%23fbbf24' font-family='monospace' font-size='12'%3EEnter choice: __%3C/text%3E%3C/svg%3E",
-    alt: "C++ CLI menu interface",
     technologies: ["C++"],
     titleColor: "text-cyan-400",
   },
@@ -62,8 +54,6 @@ export const FEATURED_PROJECTS: FeaturedProject[] = [
     title: "The 100 Prisoners Problem",
     description:
       "Inspired by Veritasium and spurred on by a debate with my professor, I coded up a simulation of the 100 prisoners problem.",
-    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='30' text-anchor='middle' fill='%2310b981' font-family='Arial' font-size='18' font-weight='bold'%3E100 Prisoners Problem%3C/text%3E%3Cg transform='translate(50,60)'%3E%3Crect x='0' y='0' width='30' height='20' fill='%236b7280' stroke='%23d1d5db'/%3E%3Ctext x='15' y='15' text-anchor='middle' fill='white' font-size='10'%3E1%3C/text%3E%3Crect x='35' y='0' width='30' height='20' fill='%236b7280' stroke='%23d1d5db'/%3E%3Ctext x='50' y='15' text-anchor='middle' fill='white' font-size='10'%3E2%3C/text%3E%3Ctext x='80' y='15' fill='%23fbbf24' font-size='12'%3E...100%3C/text%3E%3C/g%3E%3Ctext x='200' y='120' text-anchor='middle' fill='%2306b6d4' font-size='14'%3ESuccess Rate: 31.18%%3C/text%3E%3Ctext x='200' y='140' text-anchor='middle' fill='%23ef4444' font-size='12'%3ESimulations: 10,000%3C/text%3E%3Ctext x='200' y='160' text-anchor='middle' fill='%23a855f7' font-size='12'%3EStrategy: Optimal Loop%3C/text%3E%3C/svg%3E",
-    alt: "100 prisoners problem simulation visualization",
     technologies: ["C++"],
     titleColor: "text-green-400",
   },
@@ -71,8 +61,6 @@ export const FEATURED_PROJECTS: FeaturedProject[] = [
     repo: "WeatherApiApp",
     title: "Weather APP",
     description: "A classic beginning coder project.",
-    image: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Crect width='400' height='200' fill='%23111827'/%3E%3Ctext x='200' y='25' text-anchor='middle' fill='%23fbbf24' font-family='Arial' font-size='18' font-weight='bold'%3EWeather App%3C/text%3E%3Ccircle cx='120' cy='80' r='20' fill='%23fbbf24'/%3E%3Cpath d='M 100 80 Q 100 70 110 70 Q 120 60 130 70 Q 140 70 140 80' fill='%236b7280'/%3E%3Ctext x='200' y='70' fill='%23fbbf24' font-size='24' font-weight='bold'%3E72°F%3C/text%3E%3Ctext x='200' y='90' fill='%2306b6d4' font-size='14'%3ESunny%3C/text%3E%3Ctext x='200' y='110' fill='%2310b981' font-size='12'%3EGrand Junction, CO%3C/text%3E%3Ctext x='200' y='130' fill='%239ca3af' font-size='10'%3EHumidity: 45%% | Wind: 8 mph%3C/text%3E%3Ctext x='200' y='150' fill='%23a855f7' font-size='10'%3EPowered by Weather API%3C/text%3E%3C/svg%3E",
-    alt: "Weather application interface showing temperature and conditions",
     technologies: ["Python", "API", "HTML / JS"],
     titleColor: "text-yellow-400",
   },

--- a/client/src/lib/github.ts
+++ b/client/src/lib/github.ts
@@ -11,6 +11,10 @@ export interface GithubRepo {
   topics: string[];
 }
 
+export function githubOgImageUrl(repo: string): string {
+  return `https://opengraph.githubassets.com/portfolio/${GITHUB_USERNAME}/${repo}`;
+}
+
 const CACHE_KEY = "github-repos-v1";
 const CACHE_TTL_MS = 30 * 60 * 1000;
 


### PR DESCRIPTION
## What
Project cards for GitHub-backed entries now use `https://opengraph.githubassets.com/portfolio/Jaynuke79/<repo>` (verified 200 OK) instead of hand-authored SVG data-URIs. `image`/`alt` become optional overrides in the featured config.

## Why
The inline SVG mockups (some >1 KB of URL-encoded markup each, depicting invented stats) were unmaintainable and never changed. GitHub's cards update automatically as repos change — self-updating visuals for zero maintenance, matching the live-data direction of #3.

## How
- `githubOgImageUrl()` helper in `client/src/lib/github.ts`; the card falls back to it whenever a featured entry has no explicit `image`.
- The ML research entry (no repo) keeps its explicit image override, exercising the escape hatch the issue called for. It is the only remaining SVG data-URI, retained until a real figure replaces it.

## Testing
`npm run check` and `npm run build` pass; the OpenGraph URL pattern curl-verified.

Closes #5