### PR TITLE
Make the site legible to search engines and link previews

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,12 +4,30 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Jayden Alonzo-Estrada - Cybersecurity Portfolio</title>
-    <meta name="description" content="Computer Science student specializing in cybersecurity and AI at Colorado Mesa University. Explore my projects and experience.">
+    <meta name="description" content="Computer Science student specializing in cybersecurity and AI at Colorado Mesa University. ML research on IoMT network traffic, AI security demos, and open-source projects.">
     <meta name="keywords" content="cybersecurity, computer science, AI, machine learning, portfolio">
     <meta name="author" content="Jayden Alonzo-Estrada">
-    <meta property="og:title" content="Jayden Alonzo-Estrada - Cybersecurity Developer Portfolio">
-    <meta property="og:description" content="Rising junior in Computer Science with cybersecurity focus. View my projects in network security, malware analysis, and ethical hacking.">
+    <link rel="canonical" href="https://j2a3e.com/">
+    <meta property="og:title" content="Jayden Alonzo-Estrada - Cybersecurity Portfolio">
+    <meta property="og:description" content="Computer Science student specializing in cybersecurity and AI at Colorado Mesa University. ML research on IoMT network traffic, AI security demos, and open-source projects — live from GitHub.">
     <meta property="og:type" content="website">
+    <meta property="og:url" content="https://j2a3e.com/">
+    <meta property="og:image" content="https://opengraph.githubassets.com/portfolio/Jaynuke79/Portfolio">
+    <meta name="twitter:card" content="summary_large_image">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Jayden Alonzo-Estrada",
+      "url": "https://j2a3e.com/",
+      "jobTitle": "Computer Science Student",
+      "affiliation": { "@type": "CollegeOrUniversity", "name": "Colorado Mesa University" },
+      "sameAs": [
+        "https://github.com/Jaynuke79",
+        "https://www.linkedin.com/in/jayae/"
+      ]
+    }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://j2a3e.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://j2a3e.com/</loc>
+  </url>
+</urlset>

--- a/vite.config.github.ts
+++ b/vite.config.github.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     },
   },
   root: path.resolve(__dirname, "client"),
+  publicDir: path.resolve(__dirname, "public"),
   base: "./",
   build: {
     outDir: path.resolve(__dirname, "docs"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     },
   },
   root: path.resolve(__dirname, "client"),
+  publicDir: path.resolve(__dirname, "public"),
   server: {
     port: 5173,
     open: false,


### PR DESCRIPTION
## What
- `public/robots.txt` and `public/sitemap.xml`, served at the site root.
- `og:url`, `og:image` (GitHub's auto-updating OpenGraph card for the Portfolio repo), `twitter:card`, and a canonical link in `client/index.html`.
- JSON-LD `Person` markup with `sameAs` links to the GitHub and LinkedIn profiles.
- Accurate descriptions: the old `og:description` advertised "network security, malware analysis, and ethical hacking" projects that don't exist on the page; it now describes the real lineup (IoMT ML research, AI security demos, open-source repos).
- Wires the repo-root `public/` directory into both Vite configs via `publicDir`.

## Why
Sharing j2a3e.com produced a bare text preview and search engines got almost no structured signal. Separately, `public/` was never copied into the build — **the resume PDF download has been 404ing in production** (curl-verified); the `publicDir` fix repairs that too.

## How
Vite's root is `client/`, so its default publicDir (`client/public`) didn't exist; both configs now point at the repo-root `public/`.

## Testing
`npm run check` passes; `npm run build` output now contains `robots.txt`, `sitemap.xml`, and `Jayden_Alonzo-Estrada_Resume.pdf`, and `docs/index.html` carries the og:image/JSON-LD/canonical tags (verified by grep).

Closes #4