### PR TITLE
chore: drop bot submissions from the contact form

### DIFF
--- a/client/src/components/contact.test.tsx
+++ b/client/src/components/contact.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import emailjs from "@emailjs/browser";
+import Contact from "./contact";
+
+vi.mock("@emailjs/browser", () => ({
+  default: { sendForm: vi.fn().mockResolvedValue({ status: 200 }) },
+}));
+
+function fillRealFields(container: HTMLElement) {
+  fireEvent.change(container.querySelector("#name")!, { target: { value: "Ada" } });
+  fireEvent.change(container.querySelector("#email")!, { target: { value: "ada@example.com" } });
+  fireEvent.change(container.querySelector("#subject")!, { target: { value: "Hello" } });
+  fireEvent.change(container.querySelector("#message")!, { target: { value: "Hi there" } });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(emailjs.sendForm).mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("Contact form abuse protection", () => {
+  it("drops submissions that fill the honeypot field", async () => {
+    const { container } = render(<Contact />);
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    fillRealFields(container);
+    fireEvent.change(container.querySelector("#website")!, { target: { value: "spam.example" } });
+
+    await act(async () => {
+      fireEvent.submit(container.querySelector("form")!);
+    });
+
+    expect(emailjs.sendForm).not.toHaveBeenCalled();
+  });
+
+  it("drops submissions faster than a human could type", async () => {
+    const { container } = render(<Contact />);
+    fillRealFields(container);
+
+    await act(async () => {
+      fireEvent.submit(container.querySelector("form")!);
+    });
+
+    expect(emailjs.sendForm).not.toHaveBeenCalled();
+  });
+
+  it("sends a normal human submission", async () => {
+    const { container } = render(<Contact />);
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    fillRealFields(container);
+
+    await act(async () => {
+      fireEvent.submit(container.querySelector("form")!);
+    });
+
+    expect(emailjs.sendForm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/contact.tsx
+++ b/client/src/components/contact.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,12 +8,29 @@ import { useToast } from "@/hooks/use-toast";
 import { Mail, MapPin } from "lucide-react";
 import emailjs from '@emailjs/browser';
 
+const HONEYPOT_FIELD = "website";
+const MIN_FILL_TIME_MS = 3000;
+
 export default function Contact() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
+  const mountedAt = useRef(Date.now());
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const form = e.target as HTMLFormElement;
+
+    const honeypot = form.elements.namedItem(HONEYPOT_FIELD) as HTMLInputElement | null;
+    const filledTooFast = Date.now() - mountedAt.current < MIN_FILL_TIME_MS;
+    if (honeypot?.value || filledTooFast) {
+      form.reset();
+      toast({
+        title: "Message Sent!",
+        description: "Thank you for your message. I'll get back to you soon.",
+      });
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -103,6 +120,16 @@ export default function Contact() {
           <Card className="glass-morphism border-gray-800 rounded-xl">
             <CardContent className="p-8">
               <form onSubmit={handleSubmit} className="space-y-6">
+                <div className="absolute -left-[9999px] h-px w-px overflow-hidden" aria-hidden="true">
+                  <label htmlFor={HONEYPOT_FIELD}>Leave this field empty</label>
+                  <input
+                    id={HONEYPOT_FIELD}
+                    name={HONEYPOT_FIELD}
+                    type="text"
+                    tabIndex={-1}
+                    autoComplete="off"
+                  />
+                </div>
                 <div>
                   <Label htmlFor="name" className="block text-sm font-medium mb-2 text-gray-300">
                     Name

--- a/client/src/components/hero.test.tsx
+++ b/client/src/components/hero.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { StrictMode } from "react";
-import { act, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Hero from "./hero";
 
@@ -11,6 +11,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  cleanup();
   vi.useRealTimers();
 });
 


### PR DESCRIPTION
## What
Adds two cheap abuse layers to the contact form: a visually hidden honeypot field and a minimum-fill-time (3 s) check. Failing either silently drops the submission — the bot sees the same success toast a human would.

## Why
The form posts straight to EmailJS with no protection; a trivial script could drain the small monthly quota, silently killing the channel recruiters use (#20).

## How
- `contact.tsx`: off-screen `website` input (tabIndex −1, aria-hidden, autocomplete off) that humans never see; `mountedAt` ref compared against a 3-second floor at submit
- Rejected submissions reset the form and show the normal success toast, so the trap stays unadvertised
- `contact.test.tsx` (jsdom, mocked EmailJS): honeypot-filled → not sent; instant submit → not sent; human timing → sent exactly once
- Test hygiene: explicit RTL `cleanup()` in afterEach (no vitest globals, so RTL can't auto-register it); a stale mounted root plus fake timers broke subsequent renders in the same file

## Testing
- `npm run check` — clean
- `npm test` — 9/9 pass
- `npm run build` — succeeds

Not covered (needs EmailJS dashboard, noted for the issue): allowed-origins restriction on the public key and template-level reCAPTCHA.

Closes #20