### PR TITLE
docs: sync README with the upgraded toolchain and test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Visit the live portfolio: [j2a3e.com](https://j2a3e.com)
 
 ## 🛠️ Technologies Used
 
-- React 18 with TypeScript
-- Tailwind CSS for styling
+- React 19 with TypeScript
+- Tailwind CSS 4 for styling
 - Lucide React for icons
-- Vite for build tooling
+- Vite 7 for build tooling
+- Vitest for tests (typecheck, tests, and build run in CI on every PR and deploy)
 
 ## 📱 Features
 
@@ -77,6 +78,9 @@ npm run dev
 # Type-check
 npm run check
 
+# Run the test suite
+npm test
+
 # Refresh the baked GitHub project snapshot
 npm run fetch-projects
 
@@ -95,8 +99,8 @@ npm run build
 │   │   ├── lib/            # Utilities, featured-project config, GitHub data
 │   │   └── index.css       # Global styles
 │   └── index.html          # HTML template
-├── public/                 # Static assets (resume PDF, robots.txt, sitemap)
-├── scripts/                # Build-time scripts (GitHub data fetch, password hashing)
+├── public/                 # Static assets (resume PDF, images, robots.txt, sitemap)
+├── scripts/                # Build-time scripts (GitHub data fetch, booking-link encryption)
 └── .github/
     └── workflows/
         ├── ci.yml          # PR validation (typecheck, tests, build)


### PR DESCRIPTION
## What
Brings the README in line with HEAD after the issue burndown: React 19 / Tailwind 4 / Vite 7 in the tech list, Vitest + CI validation mentioned, `npm test` added to the dev commands, and the scripts/ description updated from password hashing to booking-link encryption.

## Why
The burndown (#14–#21) changed the toolchain, test story, and booking scripts; the README still described the old stack.

## Testing
Docs-only change; `npm run check` and the test suite were green on the underlying tree.